### PR TITLE
AUTHORS: drop a corrupted duplicate and an exact duplicate

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,7 +17,6 @@ Brandon Chong <bchong95@users.noreply.github.com>
 Ben Kurtovic <ben.kurtovic@gmail.com>
 dprorok2 <dprorok2@illinois.edu>
 anchal-agrawal <aagrawa4@illinois.edu>
-Lawrence Angrave <angrave@illinois.eduuutoomanyu>
 daeyun <daeyunshin@gmail.com>
 bchong95 <bschong2@illinois.edu>
 rushingseas8 <georgealeks@hotmail.com>
@@ -204,7 +203,6 @@ Aneesh Durg <durg2@illinois.edu>
 Assassin Eclipse <hungwoei96@hotmail.com>
 Eric Cao <eric7252000@gmail.com>
 Raphael Long <rafilong42@gmail.com>
-WeiL <z920631580@gmail.com>
 williamsentosa95 <38774380+williamsentosa95@users.noreply.github.com>
 Pradyumna Shome <pradyumna.shome@gmail.com>
 Benjamin West Pollak <benjaminwpollak@gmail.com>


### PR DESCRIPTION
Line 20 repeated Lawrence Angrave with a mangled address (`angrave@illinois.eduuutoomanyu`); line 2 already carries the correct entry. Line 207 repeated `WeiL <z920631580@gmail.com>` byte for byte.

Contributors listed twice under two genuinely different addresses (`dimyr7`, `briantruong777`, `hzding621`) are left alone -- those look like the same person committing from two configured emails, not defects.