### PR TITLE
Makefile: make chapter PDFs depend on the generated order.tex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,12 @@ $(MAIN_EPUB): $(ORDER_TEX) $(MAIN_TEX_SOURCE)
 $(ORDER_TEX): $(ORDER_TEX_DEP)
 	python3 _scripts/gen_order.py $^ > $@
 
-$(CHAPTER_PDF): %.pdf: %.tex
+# order.tex is generated, and main.tex \input's it, so a chapter build from
+# a clean tree needs it too. Note $< rather than $^: the recipe wants only
+# the chapter's own .tex here, not every prerequisite.
+$(CHAPTER_PDF): %.pdf: %.tex $(ORDER_TEX)
 	echo '\\let\\cleardoublepage\\clearpage' > $@.tmp
-	echo "\includeonly{$(basename $^)}\input{$(MAIN_TEX)}" >> $@.tmp
+	echo "\includeonly{$(basename $<)}\input{$(MAIN_TEX)}" >> $@.tmp
 	@latexmk -interaction=nonstopmode -quiet -pdflatex=lualatex -pdf -jobname="$@" $@.tmp \
 		|| { echo "*** latexmk failed for $@"; grep -n -A3 '^! ' $@.log 2>/dev/null; rm -f $@.tmp; false; }
 	@mv $@.pdf $@


### PR DESCRIPTION
`main.tex` `\input`s `order.tex`, which is generated from `order.yaml`, but the per-chapter rule listed only the chapter's own `.tex`. From a clean tree `make deadlock/deadlock.pdf` died with `File \`order.tex' not found`. CI never noticed, because `_scripts/script.sh` builds `all` first, which builds `order.tex` on the way to `main.pdf`.

Adding the prerequisite alone is not enough: the recipe used `$(basename $^)`, and `$^` expands to *all* prerequisites, so `\includeonly` would have gained a stray `order`. The recipe therefore switches to `$<`.

Verified in a container with CI's TeX Live package set, from a clean export with no `order.tex`: `make deadlock/deadlock.pdf` now generates `order.tex` and builds the chapter, exit 0, and the generated tmp file reads `\includeonly{deadlock/deadlock}`.