### PR TITLE
site_deploy: bump the _coursebook submodule pointer

### DIFF
--- a/_scripts/site_deploy.sh
+++ b/_scripts/site_deploy.sh
@@ -12,6 +12,29 @@ export DOCS_SHA=$(git rev-parse --short HEAD)
 git clone -b develop --depth 1 git@github.com:cs341-illinois/cs341-illinois.github.io.git ${CLONE_DIR}
 cd ${CLONE_DIR}
 
+# The site reads the coursebook through the _coursebook submodule, and its
+# workflow updates that with --remote, so the build always takes the wiki's
+# latest commit and the SHA recorded in the tree is ignored. Leaving that
+# SHA to rot is still a trap: anyone running a plain 'git submodule update'
+# builds a months-old book. Point it at the wiki commit push_to_wiki.sh
+# just published, so the recorded pointer matches what actually deploys.
+#
+# ls-remote means we never fetch the submodule: a gitlink is just an index
+# entry, so update-index can write it directly into this shallow clone.
+# Both steps are non-fatal on purpose. This script runs under 'set -e' and
+# its real job is the push below, which is what rebuilds the site; a
+# transient ls-remote failure must not cost us the rebuild.
+WIKI_SHA=$(git ls-remote "https://github.com/${GITHUB_REPOSITORY}.wiki.git" refs/heads/master | cut -f1) || true
+if [ -n "${WIKI_SHA}" ]; then
+    git update-index --add --cacheinfo "160000,${WIKI_SHA},_coursebook" \
+        || echo "Could not write the submodule pointer; pushing without the bump"
+else
+    echo "Could not resolve the wiki head; leaving the submodule pointer alone"
+fi
+
+# --allow-empty because the pointer is often already current -- there is
+# nothing to commit then, but the push still has to happen: it is the empty
+# commit that triggers the site's Website Deploy workflow.
 git commit --allow-empty -m "Updating docs to ${DOCS_SHA}"
 git push origin develop
 


### PR DESCRIPTION
The website reads the coursebook through the `_coursebook` submodule and updates it with `--remote`, so the SHA recorded in the site's tree is ignored by the build. It had drifted months behind — harmless for the published site, a trap for anyone running a plain `git submodule update`, who then builds a stale book.

`site_deploy.sh` already pushes a commit to `develop` purely to trigger `Website Deploy`. This makes that commit carry the pointer bump instead of being empty: same single commit, same trigger, but the recorded pointer now matches what actually deploys. No loop — the resulting Website Deploy makes no commit of its own.

`ls-remote` + `update-index --cacheinfo` writes the gitlink straight into the index, so the shallow clone never fetches the submodule.

Both steps are deliberately non-fatal: the script runs under `set -e`, and the push is the part that rebuilds the site, so a transient `ls-remote` failure must not cost the rebuild. `--allow-empty` stays for the same reason — when the pointer is already current there is nothing to commit, but the push still has to happen.

## Verification

Against a real shallow `--depth 1` clone of `develop`, no submodule contents fetched:

- pointer rewritten `c4b44bc` → `52aba7d`, and the resulting commit contains `_coursebook | 2 +-`
- second run with the pointer already current: still commits (empty), trigger preserved
- simulated `ls-remote` failure: logs, skips the bump, and still commits and would push

`bash -n` clean.